### PR TITLE
Fix dropdown callback

### DIFF
--- a/lib/education_screen.dart
+++ b/lib/education_screen.dart
@@ -217,7 +217,11 @@ class _EducationScreenState extends State<EducationScreen> {
       ),
       value: value.isEmpty ? null : value,
       items: years.map((year) => DropdownMenuItem(value: year, child: Text(year))).toList(),
-      onChanged: (va){},
+      onChanged: (va) {
+        if (va != null) {
+          onChanged(va);
+        }
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- wire up missing onChanged in EducationScreen dropdown

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a0f22da0832a8e3a56b4709eda5b